### PR TITLE
:art: Fix header user col width bugs

### DIFF
--- a/dev/front-end/dev_student/src/component/NewHeaderComponent/NewHeaderComponent.css
+++ b/dev/front-end/dev_student/src/component/NewHeaderComponent/NewHeaderComponent.css
@@ -176,7 +176,7 @@
 .mobile-only .header-user-col {
     float: right;
     text-align: right;
-    width: 100px;
+    /* width: 100px; */
     height: 100%;
     z-index: 2;
 }


### PR DESCRIPTION
prev -
width : "100px"

new -
width : "auto" or width 속성을 정의하지 않음

닉네임이 길어 질 경우 usercol이 두줄이 되는 문제 해결